### PR TITLE
Add aml_thermal label

### DIFF
--- a/homeassistant/components/glances/sensor.py
+++ b/homeassistant/components/glances/sensor.py
@@ -179,7 +179,7 @@ class GlancesSensor(Entity):
                                            "Package id 0", "Physical id 0",
                                            "cpu_thermal 1", "cpu-thermal 1",
                                            "exynos-therm 1", "soc_thermal 1",
-                                           "soc-thermal 1"]:
+                                           "soc-thermal 1", "aml_thermal"]:
                         self._state = sensor['value']
             elif self.type == 'docker_active':
                 count = 0


### PR DESCRIPTION
Added label for the CPU Temperature for AmLogic ARM chips.

## Description:
 CPU Temperature isn't reported for AML chips. Adding the 'aml_thermal' label for the temperature sensor fixes the issue (Tested on S812 and S905 devices.)

## Example entry for `configuration.yaml` (if applicable):
```yaml
  - platform: glances
    host: localhost
    version: 3
    resources: [ cpu_temp ]
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If the code communicates with devices, web services, or third-party tools:
  - [x] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [x] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [x] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
